### PR TITLE
Fix `md` is not defined error

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const generate = (dirPath) => {
   }
 
   var template;
+  var md;
   try {
     template = fs.readFileSync(`${dirPath}/template.ejs`, 'utf-8')
   }
@@ -27,7 +28,7 @@ const generate = (dirPath) => {
     template = fs.readFileSync(`${__dirname}/template.ejs`, 'utf-8')
   }
   try {
-    const md = fs.readFileSync(`${dirPath}/index.md`, 'utf-8')
+    md = fs.readFileSync(`${dirPath}/index.md`, 'utf-8')
   }
   catch(e) {
     console.log(e.message)


### PR DESCRIPTION
## Why

I got error of `md is not defined`.

## Summary

- use `var md;` instead of `const md = ...`.
  - because `const` is [block scope](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let).
  - test: https://jsfiddle.net/L2c668s3/3/
